### PR TITLE
Change the default transport to grpc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+tigrisdb-cli
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen

--- a/client/driver.go
+++ b/client/driver.go
@@ -25,7 +25,7 @@ import (
 var D driver.Driver
 
 func Init(config config.Config) error {
-	driver.DefaultProtocol = driver.HTTP
+	driver.DefaultProtocol = driver.GRPC
 	drv, err := driver.NewDriver(context.Background(), config.URL, &driver.Config{Token: config.Token})
 	if err != nil {
 		return err
@@ -36,7 +36,7 @@ func Init(config config.Config) error {
 	return nil
 }
 
-// Get returns an instance of instance of client
+// Get returns an instance of client
 func Get() driver.Driver {
 	return D
 }

--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,8 @@ import (
 )
 
 var DefaultConfig = Config{
-	URL: "api.apps.tigrisinternal.com",
+	Token: "e30K",
+	URL:   "api.apps.tigrisinternal.com",
 }
 
 type Config struct {
@@ -93,7 +94,4 @@ func Load(name string, config interface{}) {
 	if err := viper.Unmarshal(&config); err != nil {
 		log.Fatal().Err(err).Msg("error unmarshalling config")
 	}
-
-	//log.Debug().Interface("config", &config).Msg("final")
-	//	spew.Dump(viper.AllKeys())
 }


### PR DESCRIPTION
The default transport has been changed to grpc from http.
An empty default token is passed by default.